### PR TITLE
ファイルのチェックサム対応

### DIFF
--- a/it930x_eeprom.fbp
+++ b/it930x_eeprom.fbp
@@ -50,7 +50,7 @@
       <property name="minimum_size"></property>
       <property name="name">MainFrame</property>
       <property name="pos"></property>
-      <property name="size">620,550</property>
+      <property name="size">630,550</property>
       <property name="style">wxCAPTION|wxCLOSE_BOX</property>
       <property name="subclass">; ; forward_declare</property>
       <property name="title">it930x_eeprom</property>
@@ -440,7 +440,7 @@
                               <property name="min">0</property>
                               <property name="min_size"></property>
                               <property name="minimize_button">0</property>
-                              <property name="minimum_size">100,-1</property>
+                              <property name="minimum_size">110,-1</property>
                               <property name="moveable">1</property>
                               <property name="name">m_spinCtrlBackupVid</property>
                               <property name="pane_border">1</property>
@@ -503,7 +503,7 @@
                               <property name="min">0</property>
                               <property name="min_size"></property>
                               <property name="minimize_button">0</property>
-                              <property name="minimum_size">100,-1</property>
+                              <property name="minimum_size">110,-1</property>
                               <property name="moveable">1</property>
                               <property name="name">m_spinCtrlBackupPid</property>
                               <property name="pane_border">1</property>
@@ -1263,7 +1263,7 @@
                               <property name="min">0</property>
                               <property name="min_size"></property>
                               <property name="minimize_button">0</property>
-                              <property name="minimum_size">100,-1</property>
+                              <property name="minimum_size">110,-1</property>
                               <property name="moveable">1</property>
                               <property name="name">m_spinCtrlRestoreVid</property>
                               <property name="pane_border">1</property>
@@ -1326,7 +1326,7 @@
                               <property name="min">0</property>
                               <property name="min_size"></property>
                               <property name="minimize_button">0</property>
-                              <property name="minimum_size">100,-1</property>
+                              <property name="minimum_size">110,-1</property>
                               <property name="moveable">1</property>
                               <property name="name">m_spinCtrlRestorePid</property>
                               <property name="pane_border">1</property>

--- a/it930x_eeprom.py
+++ b/it930x_eeprom.py
@@ -615,6 +615,13 @@ class MyApp(wx.App):
                 self.textCtrlRestoreLog.AppendText('VID デバイス={:#06x} ファイル={:#06x}\n'.format(device_vid, file_vid))
                 self.textCtrlRestoreLog.AppendText('PID デバイス={:#06x} ファイル={:#06x}\n'.format(device_pid, file_pid))
 
+                # EEPROM内容の先頭2バイトは、3バイト目から最終バイトまでを合計したチェックサム
+                header_2bytes = int.from_bytes(self.restore_file_eeprom[0:2], 'big')
+                checksum = 0
+                for i in range(2, len(self.restore_file_eeprom)):
+                    checksum += self.restore_file_eeprom[i]
+                self.textCtrlRestoreLog.AppendText('ファイル 先頭2バイト={:#04x} チェックサム={:#04x}\n'.format(header_2bytes, checksum))
+
                 self.eeprom_differences = []
                 for address, vd in enumerate(self.restore_device_eeprom):
                     vf = self.restore_file_eeprom[address]
@@ -630,6 +637,13 @@ class MyApp(wx.App):
                     wx.MessageBox(msg, caption='情報')
                 elif device_vid != file_vid or device_pid != file_pid:
                     msg = 'VID:PIDがデバイス({:#06x}:{:#06x})とファイル({:#06x}:{:#06x})で一致していません。'.format(device_vid, device_pid, file_vid, file_pid)
+                    self.textCtrlRestoreLog.AppendText(msg + '\n')
+                    msg += '書き込みボタンを有効にしますか？'
+                    ret = wx.MessageBox(msg, caption='警告', style=wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING)
+                    if ret == wx.YES:
+                        self.buttonRestoreWrite.Enable()
+                elif checksum != header_2bytes:
+                    msg = 'ファイルの先頭2バイト{:#04x}がチェックサム{:#04x}と一致していません。'.format(header_2bytes, checksum)
                     self.textCtrlRestoreLog.AppendText(msg + '\n')
                     msg += '書き込みボタンを有効にしますか？'
                     ret = wx.MessageBox(msg, caption='警告', style=wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING)

--- a/it930x_eeprom_gui.py
+++ b/it930x_eeprom_gui.py
@@ -17,7 +17,7 @@ import wx.xrc
 class MainFrame ( wx.Frame ):
 
 	def __init__( self, parent ):
-		wx.Frame.__init__ ( self, parent, id = wx.ID_ANY, title = u"it930x_eeprom", pos = wx.DefaultPosition, size = wx.Size( 620,550 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.TAB_TRAVERSAL )
+		wx.Frame.__init__ ( self, parent, id = wx.ID_ANY, title = u"it930x_eeprom", pos = wx.DefaultPosition, size = wx.Size( 630,550 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.TAB_TRAVERSAL )
 
 		self.SetSizeHints( wx.DefaultSize, wx.DefaultSize )
 
@@ -50,12 +50,12 @@ class MainFrame ( wx.Frame ):
 		bSizerBackupTuner.Add( self.m_staticTextBackup3, 0, wx.ALIGN_CENTER|wx.ALL, 5 )
 
 		self.m_spinCtrlBackupVid = wx.SpinCtrl( self.m_panelBackup, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 65535, 0 )
-		self.m_spinCtrlBackupVid.SetMinSize( wx.Size( 100,-1 ) )
+		self.m_spinCtrlBackupVid.SetMinSize( wx.Size( 110,-1 ) )
 
 		bSizerBackupTuner.Add( self.m_spinCtrlBackupVid, 1, wx.ALL, 5 )
 
 		self.m_spinCtrlBackupPid = wx.SpinCtrl( self.m_panelBackup, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 65535, 0 )
-		self.m_spinCtrlBackupPid.SetMinSize( wx.Size( 100,-1 ) )
+		self.m_spinCtrlBackupPid.SetMinSize( wx.Size( 110,-1 ) )
 
 		bSizerBackupTuner.Add( self.m_spinCtrlBackupPid, 1, wx.ALL, 5 )
 
@@ -128,12 +128,12 @@ class MainFrame ( wx.Frame ):
 		bSizerRestoreVidPid = wx.BoxSizer( wx.HORIZONTAL )
 
 		self.m_spinCtrlRestoreVid = wx.SpinCtrl( self.m_panelRestore, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 65535, 1165 )
-		self.m_spinCtrlRestoreVid.SetMinSize( wx.Size( 100,-1 ) )
+		self.m_spinCtrlRestoreVid.SetMinSize( wx.Size( 110,-1 ) )
 
 		bSizerRestoreVidPid.Add( self.m_spinCtrlRestoreVid, 1, wx.ALL|wx.EXPAND, 5 )
 
 		self.m_spinCtrlRestorePid = wx.SpinCtrl( self.m_panelRestore, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, wx.SP_ARROW_KEYS, 0, 65535, 37638 )
-		self.m_spinCtrlRestorePid.SetMinSize( wx.Size( 100,-1 ) )
+		self.m_spinCtrlRestorePid.SetMinSize( wx.Size( 110,-1 ) )
 
 		bSizerRestoreVidPid.Add( self.m_spinCtrlRestorePid, 1, wx.ALL|wx.EXPAND, 5 )
 


### PR DESCRIPTION
* リストア時のEEPROMファイルに対してチェックサムを確認する処理を追加
* Xubuntu環境で実行時にGTKの警告メッセージが表示されないようにスピンボタンとダイアログのサイズを修正